### PR TITLE
[codex] Add actions security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.6
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,17 @@ name: CI
 
 on: push
 
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,37 +20,50 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
+          no-cache: true
 
       - run: bun install --frozen-lockfile
 
       - name: Parse tag
         id: tag
         run: |
-          TAG="${{ github.ref_name }}"
           # @chex/graft@0.2.0 → graft, 0.2.0
           PACKAGE=$(echo "$TAG" | sed 's/@chex\///' | sed 's/@.*//')
           VERSION=$(echo "$TAG" | sed 's/.*@//')
           echo "package=$PACKAGE" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+        env:
+          TAG: ${{ github.ref_name }}
 
       - name: Build
-        run: bun run build --filter="@chex/${{ steps.tag.outputs.package }}"
+        run: bun run build --filter="@chex/$PACKAGE"
+        env:
+          PACKAGE: ${{ steps.tag.outputs.package }}
 
       - name: Create zip
         run: |
-          cd extensions/${{ steps.tag.outputs.package }}/dist
-          zip -r ../../../${{ steps.tag.outputs.package }}-${{ steps.tag.outputs.version }}.zip .
+          cd "extensions/$PACKAGE/dist"
+          zip -r "../../../$PACKAGE-$VERSION.zip" .
+        env:
+          PACKAGE: ${{ steps.tag.outputs.package }}
+          VERSION: ${{ steps.tag.outputs.version }}
 
       - name: Extract release notes from CHANGELOG
         run: |
-          awk '/^## ${{ steps.tag.outputs.version }}$/{found=1; next} /^## /{if(found) exit} found{print}' \
-            "extensions/${{ steps.tag.outputs.package }}/CHANGELOG.md" > release-notes.md
+          awk -v version="$VERSION" '$0 == "## " version {found=1; next} /^## /{if(found) exit} found{print}' \
+            "extensions/$PACKAGE/CHANGELOG.md" > release-notes.md
+        env:
+          PACKAGE: ${{ steps.tag.outputs.package }}
+          VERSION: ${{ steps.tag.outputs.version }}
 
       - name: Create Release
         run: |
-          gh release create "${{ github.ref_name }}" \
-            "${{ steps.tag.outputs.package }}-${{ steps.tag.outputs.version }}.zip" \
-            --title "${{ steps.tag.outputs.package }} v${{ steps.tag.outputs.version }}" \
+          gh release create "$TAG" \
+            "$PACKAGE-$VERSION.zip" \
+            --title "$PACKAGE v$VERSION" \
             --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}
+          PACKAGE: ${{ steps.tag.outputs.package }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ steps.tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,19 @@ on:
     tags:
       - "@chex/*@*"
 
+permissions:
+  contents: read
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -11,3 +11,5 @@ registries:
     ref: v4.502.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: evilmartians/lefthook@v2.1.6
+  - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: zizmorcore/zizmor@v1.25.2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to commit SHAs with pinact annotations
- Add aqua-managed pinact and zizmor tools
- Add a GitHub Actions Security workflow that installs tools via aqua and runs pinact/zizmor
- Set read-only workflow permissions and disable checkout credential persistence where applicable

## Validation
- actionlint .github/workflows/*.{yml,yaml}
- git diff --check -- .github/workflows aqua.yaml
- bun run fmt